### PR TITLE
simplify python typing in target_excluder.py

### DIFF
--- a/lexsubgen/post_processors/target_excluder.py
+++ b/lexsubgen/post_processors/target_excluder.py
@@ -27,7 +27,7 @@ class TargetExcluder(PostProcessor):
         self,
         log_probs: np.ndarray,
         word2id: Dict[str, int],
-        target_words: List[str],
+        target_words: Optional[List[str]] = None,
         target_pos: Optional[List[str]] = None,
     ) -> Tuple[np.ndarray, Dict[str, int]]:
         """


### PR DESCRIPTION
Fixes #4 by simplifying python typing support in derived class of PostProcessor so that the example ipynb works without errors.